### PR TITLE
inline_html_string: remove debug print

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,7 +188,7 @@ pub fn inline_html_string<P: AsRef<Path>>(
 		css_match.as_node().detach();
 	}
 
-	dbg!(Ok(document.to_string()))
+	Ok(document.to_string())
 }
 
 fn inline_css<P: AsRef<Path>, P2: AsRef<Path>>(


### PR DESCRIPTION
removed `dbg!` macro when returning the html with inlined contents

it pollutes the console in production environment (when using `cargo --release`), but works well in a development environment

I would like to add an option to use the macro when in development mode, and remove it in production.

let me know if i did something wrong.

thanks!